### PR TITLE
Don't start tomcat as a REST consumer.

### DIFF
--- a/complete/src/main/java/hello/Application.java
+++ b/complete/src/main/java/hello/Application.java
@@ -2,22 +2,13 @@ package hello;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.boot.CommandLineRunner;
-import org.springframework.boot.SpringApplication;
-import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.web.client.RestTemplate;
 
-@SpringBootApplication
-public class Application implements CommandLineRunner {
+public class Application {
 
     private static final Logger log = LoggerFactory.getLogger(Application.class);
 
     public static void main(String args[]) {
-        SpringApplication.run(Application.class);
-    }
-
-    @Override
-    public void run(String... args) throws Exception {
         RestTemplate restTemplate = new RestTemplate();
         Quote quote = restTemplate.getForObject("http://gturnquist-quoters.cfapps.io/api/random", Quote.class);
         log.info(quote.toString());


### PR DESCRIPTION
**Removed SpringBootApplication and CommandLineRunner from Application class. So it does not start a tomcat instance on its own.**

When I tried to run a REST service provider (locally) and a consumer based on this example I found out that this consumer example also tries to start a tomcat instance. That lead to an "address already in use" exception. Apart from that it seems to be unnecessary for a consumer to start tomcat on its own.

Therefor, I removed this part from the Application class.
