### PR TITLE
Added documentation for @JsonProperty annotation

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -64,6 +64,8 @@ include::complete/src/main/java/hello/Quote.java[]
 
 As you can see, this is a simple Java class with a handful of properties and matching getter methods. It's annotated with `@JsonIgnoreProperties` from the Jackson JSON processing library to indicate that any properties not bound in this type should be ignored.
 
+In order for you to directly bind your data to your custom types, you need to specify the variable name exact same as the key in the JSON Document returned from the API. In case your variable name and key in JSON doc are not matching, you need to use `@JsonProperty` annotation to specify the exact key of JSON document.
+
 An additional class is needed to embed the inner quotation itself.
 
 `src/main/java/hello/Value.java`


### PR DESCRIPTION
In the event of non-matching of variable name and key of JSON document, the existing code will return a null value. The benefits of having a small description of @JsonProperty annotation are two folds. Firstly, it introduces the user with @JsonProperty annotation and secondly, it subtly informs the user to use the exact same variable name as the key in the JSON document.