### PR TITLE
Remove web dependency that can cause problems running the example

### DIFF
--- a/complete/build.gradle
+++ b/complete/build.gradle
@@ -13,7 +13,7 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-json'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 

--- a/complete/pom.xml
+++ b/complete/pom.xml
@@ -21,7 +21,7 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
+			<artifactId>spring-boot-starter-json</artifactId>
 		</dependency>
 
 		<dependency>

--- a/initial/build.gradle
+++ b/initial/build.gradle
@@ -13,7 +13,7 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-json'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 

--- a/initial/pom.xml
+++ b/initial/pom.xml
@@ -21,7 +21,7 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
+			<artifactId>spring-boot-starter-json</artifactId>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
If someone has the quotes server running on `localhost:8080`, and they try and run the rest-consuming example app, then it will fail as currently the app tries to start its own server on 8080, which is already occupied by the quotes server. 

Switching from `spring-boot-starter-web` dependency to `spring-boot-starter-json` prevents the consuming app from trying to start a server of its own.

An alternative way to fix this problem would be to change how the app is initialized as suggested [here](https://github.com/spring-guides/gs-consuming-rest/issues/52) This would require some explanation in the readme, but it might be a more educational fix than the one I am suggesting. 