### PR TITLE
Disable CommandLineRunner from executing during Unit tests

### DIFF
--- a/complete/src/main/java/com/example/consumingrest/ConsumingRestApplication.java
+++ b/complete/src/main/java/com/example/consumingrest/ConsumingRestApplication.java
@@ -7,6 +7,7 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Profile;
 import org.springframework.web.client.RestTemplate;
 
 @SpringBootApplication
@@ -24,6 +25,7 @@ public class ConsumingRestApplication {
 	}
 
 	@Bean
+	@Profile("!test")
 	public CommandLineRunner run(RestTemplate restTemplate) throws Exception {
 		return args -> {
 			Quote quote = restTemplate.getForObject(

--- a/complete/src/test/java/com/example/consumingrest/ConsumingRestApplicationTest.java
+++ b/complete/src/test/java/com/example/consumingrest/ConsumingRestApplicationTest.java
@@ -22,9 +22,11 @@ import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.web.client.RestTemplate;
 
 @SpringBootTest
+@ActiveProfiles("test")
 public class ConsumingRestApplicationTest {
 
 	@Autowired


### PR DESCRIPTION
Currently the code in the `complete` folder will not build successfully.

Addresses #56 